### PR TITLE
Adds utility to export countylookup results to CSV

### DIFF
--- a/cmd/countylookup/main.go
+++ b/cmd/countylookup/main.go
@@ -2,62 +2,70 @@ package main
 
 import (
 	"encoding/csv"
+	"flag"
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/corbaltcode/usps/internal/counties"
 )
 
 func main() {
-	if len(os.Args) < 2 {
-		fmt.Fprintf(os.Stderr, "Error: Missing tar file name\nUsage: %s <tar_file_name>\n", os.Args[0])
+	tarName := flag.String("tar", "", "Name of the tar file")
+	zipCode := flag.String("zip", "", "Single zip to look up (optional)")
+	flag.Parse()
+
+	if *tarName == "" {
+		fmt.Fprintf(os.Stderr, "Error: Missing tar file name\nUsage: %s -tar <tar_file_name> [-zip <optional_single_zip_code>]\n", os.Args[0])
 		os.Exit(1)
 	}
 
-	tarName := os.Args[1]
-
 	zipPassword := mustGetenv("ZIP_PASSWORD")
 
-	zipToCounty, err := counties.CollectZip4Details(tarName, zipPassword)
+	zipToCounty, err := counties.CollectZip4Details(*tarName, zipPassword)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to collect details: %v\n", err)
 		os.Exit(1)
 	}
 
-	currentDate := time.Now().Format("2006-01-02")
-	fileName := fmt.Sprintf("usps_zip_county_details_%s.csv", currentDate)
+	// Early return for the user-specified, single zip case.
+	if *zipCode != "" {
+		printCountiesForZIP(zipToCounty, *zipCode)
+		return
+	}
 
-	err = exportToCSV(zipToCounty, fileName)
+	err = exportToCSV(zipToCounty)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to export to CSV: %v\n", err)
 		os.Exit(1)
 	}
 }
 
-func exportToCSV(zipToCounty map[string][]string, fileName string) error {
-	file, err := os.Create(fileName)
-	if err != nil {
-		return fmt.Errorf("failed to create file: %w", err)
-	}
-	defer file.Close()
-
-	writer := csv.NewWriter(file)
-	defer writer.Flush()
+func exportToCSV(zipToCounty map[string][]string) error {
+	writer := os.Stdout
+	csvWriter := csv.NewWriter(writer)
+	defer csvWriter.Flush()
 
 	header := []string{"ZIP Code", "County Numbers"}
-	if err := writer.Write(header); err != nil {
+	if err := csvWriter.Write(header); err != nil {
 		return fmt.Errorf("failed to write header: %w", err)
 	}
 
 	for zip, counties := range zipToCounty {
 		record := []string{zip, fmt.Sprintf("%v", counties)}
-		if err := writer.Write(record); err != nil {
+		if err := csvWriter.Write(record); err != nil {
 			return fmt.Errorf("failed to write record: %w", err)
 		}
 	}
 
 	return nil
+}
+
+func printCountiesForZIP(zipToCounty map[string][]string, zip string) {
+	if counties, found := zipToCounty[zip]; found {
+		fmt.Printf("ZIP Code: %s, Counties: %v\n", zip, counties)
+	} else {
+		fmt.Printf("No counties found for ZIP Code: %s\n", zip)
+	}
 }
 
 func mustGetenv(key string) string {

--- a/cmd/countylookup/main.go
+++ b/cmd/countylookup/main.go
@@ -27,10 +27,15 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Early return for the user-specified, single zip case.
+	// Early return for the user-specified, single ZIP case.
 	if *zipCode != "" {
-		printCountiesForZIP(zipToCounty, *zipCode)
-		return
+		if counties, found := zipToCounty[*zipCode]; found {
+			fmt.Printf("ZIP Code: %s, Counties: %v\n", *zipCode, counties)
+			return
+		}
+
+		fmt.Printf("No counties found for ZIP Code: %s\n", *zipCode)
+		os.Exit(1)
 	}
 
 	err = exportToCSV(zipToCounty)
@@ -41,8 +46,8 @@ func main() {
 }
 
 func exportToCSV(zipToCounty map[string][]string) error {
-	writer := os.Stdout
-	csvWriter := csv.NewWriter(writer)
+	csvWriter := csv.NewWriter(os.Stdout)
+
 	defer csvWriter.Flush()
 
 	header := []string{"ZIP Code", "County Numbers"}
@@ -58,14 +63,6 @@ func exportToCSV(zipToCounty map[string][]string) error {
 	}
 
 	return nil
-}
-
-func printCountiesForZIP(zipToCounty map[string][]string, zip string) {
-	if counties, found := zipToCounty[zip]; found {
-		fmt.Printf("ZIP Code: %s, Counties: %v\n", zip, counties)
-	} else {
-		fmt.Printf("No counties found for ZIP Code: %s\n", zip)
-	}
 }
 
 func mustGetenv(key string) string {


### PR DESCRIPTION
## PR Description

- Implemented the exportToCSV function to take the zipToCounty map and write the data to standard output in CSV format.
- Added a command-line flag to allow users to view the output for a single zip code.

For context: this pr completes the second step in an implementation that will eventually do the following:
- [X] Write a program that leverages the zip4 package to print all counties associated with a zip code. * Addressed in #2 
- [X] Output data to CSV format
- [ ] Implement a function to convert county codes to county names (optional). This could make data analysis easier.
- [ ] Use the output or a similar program to find differences between USPS and the [Smarty US ZIP Code API](https://www.smarty.com/docs/cloud/us-zipcode-api).

Tested Plan
 - [X] Ran the program with a valid tar file and observed output in the generated CSV.
 - [X] Checked error messages for scenarios with a missing tar file argument.
 - [X] Checked error messages for scenarios with an invalid tar file.
 
 Output in CSV:
 ```
 ZIP Code,County Numbers
91012,[037]
91341,[037]
03765,[009]
15074,[007]
19374,[029]
29605,[045]
52043,[043]
74149,[143]
78239,[029]
81138,[023]
19609,[011]
36123,[101]
36456,[013 039 035]
// ... more rows ...
```

## PR Checklist
* [no] **New automated tests have been written to the extent possible.**
* [yes, ran `go build ./cmd/countylookup` without incident ] **The code has been checked for structural/syntactic validity.**
	- AMI/application: a build was performed
	- terraform changes: "terraform plan" checked on every affected environment
* [n/a] **(If applicable) the code has been manually tested on our infrastructure.**
	- AMI/application: deployed an a test or dev environment
	- terraform changes: applied to test or dev environment
	- script: run against test or dev environment
* [n/a] **Likely failure points and new functionality have been identified and tested manually.**
	Examples:
	- Application manually run in a way that triggers any new branches
	- AMI logged into and changes verified from login shell
* [yes, see above] **Pull request description includes a description of all the manual steps performed to accomplish the above.**

To provide feedback on this template, visit https://docs.google.com/document/d/1YfTv7Amyop5G_8w1c2GJ_Mu-70L0KkZHhm9f9umDi3U/edit
